### PR TITLE
fix: ensure contact form UI renders client-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Dependencies
+node_modules/
+
+# Next.js build output
+.next/
+out/
+
+# Misc
+next-env.d.ts
+

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
## Summary
- mark Button, Card, Input, and Textarea as client components
- ignore Next.js build artifacts and dependencies in git

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a05f9543408329934cbeeeeecc742d